### PR TITLE
fix conda badge

### DIFF
--- a/docs/02_installation.md
+++ b/docs/02_installation.md
@@ -5,7 +5,7 @@ permalink: /install/
 ---
 
 
-![image](https://anaconda.org/conda-forge/mss/badges/installer/conda.svg)
+![image](https://img.shields.io/badge/Install%20with-conda-green.svg?style=flat-square)
 
 
 ## Install distributed version by conda


### PR DESCRIPTION
fix conda badge on https://open-mss.github.io/install/
previously, "https://anaconda.org/conda-forge/mss/badges/installer/conda.svg" was redirected to "https://img.shields.io/badge/Install%20with-conda-green.svg?style=flat-square"
![image](https://github.com/Open-MSS/Open-MSS.github.io/assets/45981130/e41c6a01-097a-4461-be92-018ff21b4ecb)
now redirection doesn't work